### PR TITLE
ToolKitFix

### DIFF
--- a/src/com/twojr/toolkit/JArray.java
+++ b/src/com/twojr/toolkit/JArray.java
@@ -26,17 +26,8 @@ public class JArray extends JData{
     public JArray(JData[] value) {
 
         super(ARRAY, ARRAY_NAME, 0);
-        int size = 0;
-
-        for(JData data : value){
-
-            size += data.getSize();
-
-        }
-
-        setSize(size);
-
         this.value = value;
+        setSize(computeSize());
     }
 
     //==================================================================================================================
@@ -50,16 +41,7 @@ public class JArray extends JData{
     public void setValue(JData[] value) {
 
         this.value = value;
-
-        int size = 0;
-
-        for(JData data : value){
-
-            size += data.getSize();
-
-        }
-
-        setSize(size);
+        setSize(computeSize());
 
     }
 
@@ -96,13 +78,7 @@ public class JArray extends JData{
     @Override
     public byte[] toByte() {
 
-        int size = 0;
-
-        for(JData data : value){
-
-            size += data.getSize();
-
-        }
+        int size = getSize();
 
         byte bytes[] = new byte[size];
         int arrayIndex = 0;
@@ -127,5 +103,17 @@ public class JArray extends JData{
     //==================================================================================================================
     // Private Functions(s)
     //==================================================================================================================
+
+    private int computeSize() {
+        int size = 0;
+
+        for(JData data : value){
+
+            size += data.getSize();
+
+        }
+
+        return size;
+    }
 
 } /*********************************************END OF FILE*************************************************************/

--- a/src/com/twojr/toolkit/JBitmap.java
+++ b/src/com/twojr/toolkit/JBitmap.java
@@ -3,6 +3,7 @@ package com.twojr.toolkit;
 import java.util.HashMap;
 
 import static com.twojr.toolkit.DataTypes.*;
+import static com.twojr.toolkit.JDataSizes.*;
 
 /**
  * Created by rcunni002c on 11/17/2016.
@@ -11,29 +12,29 @@ public class JBitmap extends JData {
 
     public static final String BITMAP = "Bitmap";
 
-    private HashMap<Integer,Integer> value;
-    private HashMap<Integer,String> params;
+    private HashMap<Integer, Integer> value;
+    private HashMap<Integer, String> params;
 
 
     //==================================================================================================================
     // Constructor(s)
     //==================================================================================================================
 
-    public JBitmap(){
+    public JBitmap() {
 
         super(EIGHT_BIT_MAP_DATA, BITMAP, JDataSizes.EIGHT_BIT);
 
         this.params = new HashMap<>();
 
-        for(int i = 0; i < getSize(); i++){
-            params.put(i,"");
+        for (int i = 0; i < getSize(); i++) {
+            params.put(i, "");
         }
 
 
         this.value = new HashMap<>();
 
-        for(int i = 0; i < getSize(); i++){
-            value.put(i,0);
+        for (int i = 0; i < getSize(); i++) {
+            value.put(i, 0);
         }
 
     }
@@ -41,60 +42,19 @@ public class JBitmap extends JData {
     public JBitmap(JDataSizes size) {
 
         super(EIGHT_BIT_MAP_DATA, BITMAP, size);
-
-        int id;
-        switch (size){
-
-            case EIGHT_BIT:
-                id = EIGHT_BIT_MAP_DATA;
-                break;
-
-            case SIXTEEN_BIT:
-                id = SIXTEEN_BIT_MAP_DATA;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                id = TWENTY_FOUR_BIT_MAP_DATA;
-                break;
-
-            case THIRTY_TWO_BIT:
-                id = THIRTY_TWO_BIT_MAP_DATA;
-                break;
-
-            case FORTY_BIT:
-                id = FORTY_BIT_MAP_DATA;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                id = FORTY_EIGHT_BIT_MAP_DATA;
-                break;
-
-            case FIFTY_SIX_BIT:
-                id = FIFTY_SIX_BIT_MAP_DATA;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                id = SIXTY_FOUR_BIT_MAP_DATA;
-                break;
-
-            default:
-                id = EIGHT_BIT_MAP_DATA;
-                break;
-        }
-
-        setId(id);
+        setId(computeId(size));
 
         this.params = new HashMap<>();
 
-        for(int i = 0; i < getSize(); i++){
-            params.put(i,"");
+        for (int i = 0; i < getSize(); i++) {
+            params.put(i, "");
         }
 
 
         this.value = new HashMap<>();
 
-        for(int i = 0; i < getSize(); i++){
-            value.put(i,0);
+        for (int i = 0; i < getSize(); i++) {
+            value.put(i, 0);
         }
 
     }
@@ -103,45 +63,7 @@ public class JBitmap extends JData {
 
         super(EIGHT_BIT_MAP_DATA, BITMAP, size);
 
-        int id;
-        switch (size){
-
-            case EIGHT_BIT:
-                id = EIGHT_BIT_MAP_DATA;
-                break;
-
-            case SIXTEEN_BIT:
-                id = SIXTEEN_BIT_MAP_DATA;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                id = TWENTY_FOUR_BIT_MAP_DATA;
-                break;
-
-            case THIRTY_TWO_BIT:
-                id = THIRTY_TWO_BIT_MAP_DATA;
-                break;
-
-            case FORTY_BIT:
-                id = FORTY_BIT_MAP_DATA;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                id = FORTY_EIGHT_BIT_MAP_DATA;
-                break;
-
-            case FIFTY_SIX_BIT:
-                id = FIFTY_SIX_BIT_MAP_DATA;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                id = SIXTY_FOUR_BIT_MAP_DATA;
-                break;
-
-            default:
-                id = EIGHT_BIT_MAP_DATA;
-                break;
-        }
+        setId(computeId(size));
         this.value = value;
         this.params = params;
 
@@ -189,16 +111,16 @@ public class JBitmap extends JData {
 
     }
 
-    public int getValues(int i){
+    public int getValues(int i) {
 
         if (i > 0 && i <= getSize() * 8) {
 
             return value.get(i);
 
-        }else {
+        } else {
 
 
-            return  -1;
+            return -1;
 
         }
 
@@ -210,14 +132,13 @@ public class JBitmap extends JData {
 
         byte[] bytes = new byte[getSize()];
 
-        for(int i = 0; i < getSize(); i++){
+        for (int i = 0; i < getSize(); i++) {
 
             String byteStr = "";
 
-            for(int j = 0; j < 8; j++)
-            {
+            for (int j = 0; j < 8; j++) {
 
-                byteStr += value.get(j + i*8);
+                byteStr += value.get(j + i * 8);
 
             }
 
@@ -233,16 +154,16 @@ public class JBitmap extends JData {
 
         String output = "";
 
-        for(int key : value.keySet()){
+        for (int key : value.keySet()) {
 
-            output +=  key + ". value: " + value.get(key) + ", param: " + params.get(key) + "\n";
+            output += key + ". value: " + value.get(key) + ", param: " + params.get(key) + "\n";
 
         }
 
         System.out.print(output);
 
         return output;
-        
+
     }
 
     @Override
@@ -259,5 +180,51 @@ public class JBitmap extends JData {
     //==================================================================================================================
     // Private Functions(s)
     //==================================================================================================================
+
+    private int computeId(JDataSizes size) {
+
+        int id;
+        switch(size)
+        {
+            case EIGHT_BIT:
+                id = EIGHT_BIT_MAP_DATA;
+                break;
+
+            case SIXTEEN_BIT:
+               id = SIXTEEN_BIT_MAP_DATA;
+               break;
+
+            case TWENTY_FOUR_BIT:
+               id = TWENTY_FOUR_BIT_MAP_DATA;
+               break;
+
+            case THIRTY_TWO_BIT:
+               id = THIRTY_TWO_BIT_MAP_DATA;
+               break;
+
+            case FORTY_BIT:
+               id = FORTY_BIT_MAP_DATA;
+               break;
+
+            case FORTY_EIGHT_BIT:
+               id = FORTY_EIGHT_BIT_MAP_DATA;
+               break;
+
+            case FIFTY_SIX_BIT:
+                id = FIFTY_SIX_BIT_MAP_DATA;
+                break;
+
+            case SIXTY_FOUR_BIT:
+                id = SIXTY_FOUR_BIT_MAP_DATA;
+                break;
+
+            default:
+                id = EIGHT_BIT_MAP_DATA;
+                break;
+
+        }
+
+        return id;
+    }
 
 } /*********************************************END OF FILE*************************************************************/

--- a/src/com/twojr/toolkit/JData.java
+++ b/src/com/twojr/toolkit/JData.java
@@ -26,72 +26,7 @@ public abstract class JData extends JIdentity implements ISendable{
     public JData(int id, String name, JDataSizes size) {
         super(id, name);
 
-        switch (size){
-
-            case EIGHT_BIT:
-                this.size = 1;
-                break;
-
-            case SIXTEEN_BIT:
-                this.size = 2;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                this.size = 3;
-                break;
-
-            case THIRTY_TWO_BIT:
-                this.size = 4;
-                break;
-
-            case FORTY_BIT:
-                this.size = 5;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                this.size = 6;
-                break;
-
-            case FIFTY_SIX_BIT:
-                this.size = 7;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                this.size = 8;
-                break;
-
-            case SEVENTY_TWO_BIT:
-                this.size = 9;
-                break;
-
-            case EIGHTY_BIT:
-                this.size = 10;
-                break;
-
-            case EIGHTY_EIGHT_BIT:
-                this.size = 11;
-                break;
-
-            case NINETY_SIX_BIT:
-                this.size = 12;
-                break;
-
-            case HUNDRED_FOUR_BIT:
-                this.size = 13;
-                break;
-
-            case HUNDRED_TWELVE_BIT:
-                this.size = 14;
-                break;
-
-            case HUNDRED_TWENTY_BIT:
-                this.size = 15;
-                break;
-
-            case HUNDRED_TWENTY_EIGHT_BIT:
-                this.size = 16;
-                break;
-        }
+        this.size = size.ordinal();
     }
 
     //==================================================================================================================
@@ -108,72 +43,7 @@ public abstract class JData extends JIdentity implements ISendable{
 
     public void setSize(JDataSizes size){
 
-        switch (size){
-
-            case EIGHT_BIT:
-                this.size = 1;
-                break;
-
-            case SIXTEEN_BIT:
-                this.size = 2;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                this.size = 3;
-                break;
-
-            case THIRTY_TWO_BIT:
-                this.size = 4;
-                break;
-
-            case FORTY_BIT:
-                this.size = 5;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                this.size = 6;
-                break;
-
-            case FIFTY_SIX_BIT:
-                this.size = 7;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                this.size = 8;
-                break;
-
-            case SEVENTY_TWO_BIT:
-                this.size = 9;
-                break;
-
-            case EIGHTY_BIT:
-                this.size = 10;
-                break;
-
-            case EIGHTY_EIGHT_BIT:
-                this.size = 11;
-                break;
-
-            case NINETY_SIX_BIT:
-                this.size = 12;
-                break;
-
-            case HUNDRED_FOUR_BIT:
-                this.size = 13;
-                break;
-
-            case HUNDRED_TWELVE_BIT:
-                this.size = 14;
-                break;
-
-            case HUNDRED_TWENTY_BIT:
-                this.size = 15;
-                break;
-
-            case HUNDRED_TWENTY_EIGHT_BIT:
-                this.size = 16;
-                break;
-        }
+        this.size = size.ordinal();
     }
 
 

--- a/src/com/twojr/toolkit/JDataSizes.java
+++ b/src/com/twojr/toolkit/JDataSizes.java
@@ -4,7 +4,7 @@ package com.twojr.toolkit;
  * Created by rcunni002c on 1/15/2017.
  */
 public enum JDataSizes {
-
+    NULL,
     EIGHT_BIT,                  //8 bit, 1 byte
     SIXTEEN_BIT,                //16 bit, 2 byte
     TWENTY_FOUR_BIT,            //24 bit, 3 byte

--- a/src/com/twojr/toolkit/JKey.java
+++ b/src/com/twojr/toolkit/JKey.java
@@ -74,7 +74,8 @@ public class JKey extends JData{
 
     @Override
     public byte[] toByte() {
-        return new byte[0];
+
+        return value;
     }
 
     //==================================================================================================================

--- a/src/com/twojr/toolkit/integer/JSignedInteger.java
+++ b/src/com/twojr/toolkit/integer/JSignedInteger.java
@@ -27,52 +27,10 @@ public class JSignedInteger extends JInteger {
     }
     public JSignedInteger(JDataSizes size, int value) {
 
-        super(SIGNED_EIGHT_BIT_INT, SIGNED_INTEGER, EIGHT_BIT, value);
+        super(SIGNED_EIGHT_BIT_INT, SIGNED_INTEGER, size, value);
 
-        int id;
+        setId(computeId(size));
 
-        switch (size){
-
-            case EIGHT_BIT:
-                id = SIGNED_EIGHT_BIT_INT;
-                break;
-
-            case SIXTEEN_BIT:
-                id = SIGNED_SIXTEEN_BIT_INT;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                id = SIGNED_TWENTY_FOUR_BIT_INT;
-                break;
-
-            case THIRTY_TWO_BIT:
-                id = SIGNED_THIRTY_TWO_BIT_INT;
-                break;
-
-            case FORTY_BIT:
-                id = SIGNED_FORTY_BIT_INT;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                id = SIGNED_FORTY_EIGHT_BIT_INT;
-                break;
-
-            case FIFTY_SIX_BIT:
-               id = SIGNED_FIFTY_SIX_BIT_INT;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                id = SIGNED_SIXTY_FOUR_BIT_INT;
-                break;
-
-            default:
-                id = SIGNED_EIGHT_BIT_INT;
-                setSize(1);
-                break;
-
-        }
-
-        setId(id);
     }
 
 
@@ -111,4 +69,49 @@ public class JSignedInteger extends JInteger {
     // Private Functions(s)
     //==================================================================================================================
 
+    private int computeId(JDataSizes size) {
+        int id;
+
+        switch (size){
+
+            case EIGHT_BIT:
+                id = SIGNED_EIGHT_BIT_INT;
+                break;
+
+            case SIXTEEN_BIT:
+                id = SIGNED_SIXTEEN_BIT_INT;
+                break;
+
+            case TWENTY_FOUR_BIT:
+                id = SIGNED_TWENTY_FOUR_BIT_INT;
+                break;
+
+            case THIRTY_TWO_BIT:
+                id = SIGNED_THIRTY_TWO_BIT_INT;
+                break;
+
+            case FORTY_BIT:
+                id = SIGNED_FORTY_BIT_INT;
+                break;
+
+            case FORTY_EIGHT_BIT:
+                id = SIGNED_FORTY_EIGHT_BIT_INT;
+                break;
+
+            case FIFTY_SIX_BIT:
+                id = SIGNED_FIFTY_SIX_BIT_INT;
+                break;
+
+            case SIXTY_FOUR_BIT:
+                id = SIGNED_SIXTY_FOUR_BIT_INT;
+                break;
+
+            default:
+                id = SIGNED_EIGHT_BIT_INT;
+                setSize(1);
+                break;
+
+        }
+        return id;
+    }
 } /*********************************************END OF FILE*************************************************************/

--- a/src/com/twojr/toolkit/integer/JUnsignedInteger.java
+++ b/src/com/twojr/toolkit/integer/JUnsignedInteger.java
@@ -28,52 +28,9 @@ public class JUnsignedInteger extends JInteger{
 
     public JUnsignedInteger(JDataSizes size, int value) {
 
-        super(UNSIGNED_EIGHT_BIT_INT, UNSIGNED_INTEGER, EIGHT_BIT, value);
+        super(UNSIGNED_EIGHT_BIT_INT, UNSIGNED_INTEGER, size, value);
 
-        int id;
-
-        switch (size){
-
-            case EIGHT_BIT:
-                id = SIGNED_EIGHT_BIT_INT;
-                break;
-
-            case SIXTEEN_BIT:
-                id = SIGNED_SIXTEEN_BIT_INT;
-                break;
-
-            case TWENTY_FOUR_BIT:
-                id = SIGNED_TWENTY_FOUR_BIT_INT;
-                break;
-
-            case THIRTY_TWO_BIT:
-                id = SIGNED_THIRTY_TWO_BIT_INT;
-                break;
-
-            case FORTY_BIT:
-                id = SIGNED_FORTY_BIT_INT;
-                break;
-
-            case FORTY_EIGHT_BIT:
-                id = SIGNED_FORTY_EIGHT_BIT_INT;
-                break;
-
-            case FIFTY_SIX_BIT:
-                id = SIGNED_FIFTY_SIX_BIT_INT;
-                break;
-
-            case SIXTY_FOUR_BIT:
-                id = SIGNED_SIXTY_FOUR_BIT_INT;
-                break;
-
-            default:
-                id = SIGNED_EIGHT_BIT_INT;
-                setSize(1);
-                break;
-
-        }
-
-        setId(id);
+        setId(computeId(size));
     }
 
     //==================================================================================================================
@@ -118,4 +75,51 @@ public class JUnsignedInteger extends JInteger{
     // Private Functions(s)
     //==================================================================================================================
 
+    private int computeId(JDataSizes size) {
+
+        int id;
+
+        switch (size){
+
+            case EIGHT_BIT:
+                id = UNSIGNED_EIGHT_BIT_INT;
+                break;
+
+            case SIXTEEN_BIT:
+                id = UNSIGNED_SIXTEEN_BIT_INT;
+                break;
+
+            case TWENTY_FOUR_BIT:
+                id = UNSIGNED_TWENTY_FOUR_BIT_INT;
+                break;
+
+            case THIRTY_TWO_BIT:
+                id = UNSIGNED_THIRTY_TWO_BIT_INT;
+                break;
+
+            case FORTY_BIT:
+                id = UNSIGNED_FORTY_BIT_INT;
+                break;
+
+            case FORTY_EIGHT_BIT:
+                id = UNSIGNED_FORTY_EIGHT_BIT_INT;
+                break;
+
+            case FIFTY_SIX_BIT:
+                id = UNSIGNED_FIFTY_SIX_BIT_INT;
+                break;
+
+            case SIXTY_FOUR_BIT:
+                id = UNSIGNED_SIXTY_FOUR_BIT_INT;
+                break;
+
+            default:
+                id = UNSIGNED_EIGHT_BIT_INT;
+                setSize(1);
+                break;
+
+        }
+
+        return id;
+    }
 } /*********************************************END OF FILE*************************************************************/

--- a/src/com/twojr/toolkit/test/JArrayTest.java
+++ b/src/com/twojr/toolkit/test/JArrayTest.java
@@ -5,8 +5,10 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
+import static com.twojr.toolkit.DataTypes.DOUBLE_PRECISION;
 import static com.twojr.toolkit.DataTypes.EIGHT_BIT_MAP_DATA;
 import static com.twojr.toolkit.JDataSizes.EIGHT_BIT;
+import static com.twojr.toolkit.JDataSizes.SIXTY_FOUR_BIT;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -22,7 +24,20 @@ public class JArrayTest {
         JData array[] = {jBit};
         JArray jArray = new JArray(array);
 
-        assertEquals(jArray.toByte(),0);
+        assertEquals(jArray.toByte()[0],0);
+
+
+        JDouble array2[] = {new JDouble(10392),new JDouble(9382.392),new JDouble(83)};
+        JArray doubArray = new JArray(array2);
+        byte[] output = doubArray.toByte();
+
+        // Test Array
+        byte[] expected = {(byte) 0x40, (byte) 0xC4, (byte) 0x4C, (byte)0x00, (byte)0x00, (byte) 0x00,(byte) 0x00,(byte) 0x00,  //10392
+                (byte) 0x40, (byte) 0xC2, (byte) 0x53, (byte) 0x32, (byte) 0x2D, (byte) 0x0E, (byte) 0x56, (byte) 0x04,     // 9382.392
+                (byte) 0x40, (byte) 0x54, (byte) 0xC0, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00 };   // 83
+
+        for(int i=0; i < (3*SIXTY_FOUR_BIT.ordinal()); i++)
+                assertEquals(expected[i],output[i]);
 
     }
 

--- a/src/com/twojr/toolkit/test/JBitmapTest.java
+++ b/src/com/twojr/toolkit/test/JBitmapTest.java
@@ -23,7 +23,7 @@ public class JBitmapTest {
 
         JBitmap jBitmap = new JBitmap();
 
-        assertEquals(jBitmap.toByte(),0);
+        assertEquals(0, jBitmap.toByte());
 
     }
 
@@ -34,7 +34,7 @@ public class JBitmapTest {
 
         JBitmap jBitmap = new JBitmap();
 
-        assertEquals(jBitmap.getValue(),0);
+        assertEquals(0, jBitmap.getValue());
 
     }
 
@@ -56,7 +56,7 @@ public class JBitmapTest {
 
         jBitmap.setValue(values);
 
-        assertEquals(jBitmap.getValue(),1);
+        assertEquals(1, jBitmap.getValue());
 
     }
 
@@ -66,7 +66,7 @@ public class JBitmapTest {
 
         JBitmap jBitmap = new JBitmap();
 
-        assertEquals(jBitmap.getValues(0),0);
+        assertEquals(0, jBitmap.getValues(0));
 
 
     }
@@ -79,7 +79,7 @@ public class JBitmapTest {
 
         jBitmap.putValue(0,true);
 
-        assertEquals(jBitmap.getValues(0),1);
+        assertEquals(1,jBitmap.getValues(0));
 
     }
 
@@ -101,7 +101,7 @@ public class JBitmapTest {
 
         }
         
-        assertEquals(jBitmap.getValue(),output);
+        assertEquals(output,jBitmap.print());
 
     }
 

--- a/src/com/twojr/toolkit/test/JBooleanTest.java
+++ b/src/com/twojr/toolkit/test/JBooleanTest.java
@@ -1,4 +1,7 @@
 package com.twojr.toolkit.test;
+import static com.twojr.toolkit.DataTypes.BOOLEAN;
+import static com.twojr.toolkit.JDataSizes.EIGHT_BIT;
+import static com.twojr.toolkit.JDataSizes.NULL;
 import static org.junit.Assert.*;
 
 import com.twojr.toolkit.JBoolean;
@@ -19,7 +22,7 @@ public class JBooleanTest {
         JBoolean boolean1 = new JBoolean(value);
 
         assertEquals(size,boolean1.toByte().length);
-        assertEquals(0x01, boolean1.toByte()[0]);
+        assertEquals((byte) 0x01, boolean1.toByte()[0]);
     }
 
     @Test
@@ -71,7 +74,7 @@ public class JBooleanTest {
 
 
         JBoolean jBoolean = new JBoolean(value);
-        assertEquals(id, jBoolean.getId());
+        assertEquals(BOOLEAN, jBoolean.getId());
     }
 
     @Test
@@ -85,7 +88,7 @@ public class JBooleanTest {
 
         JBoolean jBoolean = new JBoolean(value);
 
-        assertEquals(name, jBoolean.getName());
+        assertEquals("Boolean", jBoolean.getName());
     }
 
     @Test
@@ -133,7 +136,7 @@ public class JBooleanTest {
         JBoolean jBoolean = new JBoolean();
 
 
-        assertEquals(0, jBoolean.getId());
+        assertEquals(BOOLEAN, jBoolean.getId());
         jBoolean.setId(12);
         assertEquals(12, jBoolean.getId());
 
@@ -143,9 +146,9 @@ public class JBooleanTest {
     public void evaluateSetSize() {
         JBoolean jBoolean = new JBoolean();
 
-        assertEquals(0, jBoolean.getSize());
-        jBoolean.setSize(1);
-        assertEquals(1, jBoolean.getSize());
+        assertEquals(EIGHT_BIT.ordinal(), jBoolean.getSize());
+        jBoolean.setSize(NULL.ordinal());
+        assertEquals(NULL.ordinal(), jBoolean.getSize());
 
     }
 
@@ -153,7 +156,7 @@ public class JBooleanTest {
     public void evaluateSetName() {
         JBoolean jBoolean = new JBoolean();
 
-        assertEquals(null, jBoolean.getName());
+        assertEquals("Boolean", jBoolean.getName());
         jBoolean.setName("name");
         assertEquals("name", jBoolean.getName());
     }

--- a/src/com/twojr/toolkit/test/JDoubleTest.java
+++ b/src/com/twojr/toolkit/test/JDoubleTest.java
@@ -1,6 +1,9 @@
 package com.twojr.toolkit.test;
+import static com.twojr.toolkit.DataTypes.DOUBLE_PRECISION;
+import static com.twojr.toolkit.JDataSizes.SIXTY_FOUR_BIT;
 import static org.junit.Assert.*;
 
+import com.twojr.toolkit.JDataSizes;
 import com.twojr.toolkit.JDouble;
 import org.junit.Test;
 import java.nio.ByteBuffer;
@@ -12,15 +15,37 @@ public class JDoubleTest {
     @Test
     public void evaluateToByte() {
         double value = 201902;
+
+        byte[] expectedValue = {(byte) 0x41, (byte)0x08, (byte) 0xA5, (byte) 0x70,
+                (byte) 0x00,(byte) 0x00,(byte) 0x00,(byte) 0x00};
         int size = 8;
         int id = 1;
         String name = "name";
 
         JDouble jDouble = new JDouble(value);
-        assertEquals(ByteBuffer.wrap(jDouble.toByte()).getDouble(),value,0);
+        for(int i=0; i<size; i++)
+            assertEquals(expectedValue[i],jDouble.toByte()[i]);
+
     }
 
     @Test
+    public void evaluateToByteDecimal() {
+
+        double value = 10.39284;
+
+        byte[] expectedValue = {(byte) 0x40, (byte) 0x24, (byte) 0xC9, (byte) 0x22,
+                (byte) 0x53, (byte) 0x11, (byte) 0x1F, (byte) 0x0C};
+        int size = 8;
+        int id = 1;
+        String name = "name";
+
+        JDouble jDouble = new JDouble(value);
+        for (int i = 0; i < size; i++)
+            assertEquals(expectedValue[i], jDouble.toByte()[i]);
+
+    }
+
+        @Test
     public void evaluateGetSize() {
         double value = 201902;
         int size = 8;
@@ -49,9 +74,8 @@ public class JDoubleTest {
         int id = 1;
         String name = "name";
 
-
         JDouble jDouble = new JDouble(value);
-        assertEquals(jDouble.getId(),id);
+        assertEquals(jDouble.getId(),DOUBLE_PRECISION);
     }
 
     @Test
@@ -63,7 +87,7 @@ public class JDoubleTest {
 
         JDouble jDouble = new JDouble(value);
 
-        assertEquals(jDouble.getName(),name);
+        assertEquals(jDouble.getName(),"Double");
     }
 
     @Test
@@ -94,7 +118,7 @@ public class JDoubleTest {
         JDouble jDouble = new JDouble();
 
 
-        assertEquals(0, jDouble.getId());
+        assertEquals(DOUBLE_PRECISION, jDouble.getId());
         jDouble.setId(12);
         assertEquals(12, jDouble.getId());
 
@@ -104,9 +128,9 @@ public class JDoubleTest {
     public void evaluateSetSize() {
         JDouble jDouble = new JDouble();
 
-        assertEquals(0, jDouble.getSize());
-        jDouble.setSize(8);
-        assertEquals(8, jDouble.getSize());
+        assertEquals(SIXTY_FOUR_BIT.ordinal(), jDouble.getSize());
+        jDouble.setSize(SIXTY_FOUR_BIT.ordinal());
+        assertEquals(SIXTY_FOUR_BIT.ordinal(), jDouble.getSize());
 
     }
 
@@ -114,7 +138,7 @@ public class JDoubleTest {
     public void evaluateSetName() {
         JDouble jDouble = new JDouble();
 
-        assertEquals(null, jDouble.getName());
+        assertEquals("Double", jDouble.getName());
         jDouble.setName("name");
         assertEquals("name", jDouble.getName());
     }

--- a/src/com/twojr/toolkit/test/JKeyTest.java
+++ b/src/com/twojr/toolkit/test/JKeyTest.java
@@ -22,7 +22,8 @@ public class JKeyTest {
 
         JKey jKey = new JKey(address);
 
-        assertEquals(jKey.toByte(),address);
+        for(int i=0; i<address.length; i++)
+        assertEquals(address[i], jKey.toByte()[i]);
 
     }
 
@@ -34,7 +35,7 @@ public class JKeyTest {
 
         JKey jKey = new JKey(address);
 
-        assertEquals(jKey.getValue(),address);
+        assertEquals(address, jKey.getValue());
     }
 
     @Test
@@ -47,7 +48,7 @@ public class JKeyTest {
         JKey jKey = new JKey(address1);
 
         jKey.setValue(address2);
-        assertEquals(jKey.getValue(),address2);
+        assertEquals(address2, jKey.getValue());
 
     }
 
@@ -58,7 +59,7 @@ public class JKeyTest {
 
         byte[] address = {00,00,00,00,00,00,00,00};
 
-        JAddress jAddress = new JAddress(address);
+        JKey jAddress = new JKey(address);
 
         String output = "Key: ";
 
@@ -72,7 +73,7 @@ public class JKeyTest {
 
 
 
-        assertEquals(jAddress.print(),output);
+        assertEquals(output, jAddress.print());
 
     }
 

--- a/src/com/twojr/toolkit/test/JSignedIntegerTest.java
+++ b/src/com/twojr/toolkit/test/JSignedIntegerTest.java
@@ -2,6 +2,7 @@ package com.twojr.toolkit.test;
 import static com.twojr.toolkit.JDataSizes.*;
 import static org.junit.Assert.*;
 
+import com.twojr.toolkit.DataTypes;
 import com.twojr.toolkit.JDataSizes;
 import com.twojr.toolkit.integer.JSignedInteger;
 import org.junit.Test;
@@ -62,10 +63,10 @@ public class JSignedIntegerTest {
     public void evalueateGetId() {
         int value = 0;
         int size = 1;
-        int id = 1;
+        int id = DataTypes.SIGNED_THIRTY_TWO_BIT_INT;
         String name = "test_name";
 
-        JSignedInteger sIntTest = new JSignedInteger(EIGHT_BIT, value);
+        JSignedInteger sIntTest = new JSignedInteger(JDataSizes.THIRTY_TWO_BIT, value);
         assertEquals(id, sIntTest.getId());
     }
 
@@ -77,6 +78,9 @@ public class JSignedIntegerTest {
         String name = "test_name";
 
         JSignedInteger sIntTest = new JSignedInteger(EIGHT_BIT, value);
+        assertEquals("Signed Integer", sIntTest.getName());
+
+        sIntTest.setName(name);
         assertEquals(name, sIntTest.getName());
     }
 
@@ -118,7 +122,7 @@ public class JSignedIntegerTest {
     public void evaluateSetId() {
         JSignedInteger sIntTest = new JSignedInteger();
 
-        assertEquals(0, sIntTest.getId());
+        assertEquals(DataTypes.SIGNED_EIGHT_BIT_INT, sIntTest.getId());
         sIntTest.setId(12);
         assertEquals(12, sIntTest.getId());
     }
@@ -127,16 +131,16 @@ public class JSignedIntegerTest {
     public void evaluateSetSize() {
         JSignedInteger sIntTest = new JSignedInteger();
 
-        assertEquals(0, sIntTest.getSize());
-        sIntTest.setSize(1);
         assertEquals(1, sIntTest.getSize());
+        sIntTest.setSize(0);
+        assertEquals(0, sIntTest.getSize());
     }
 
     @Test
     public void evaluateSetName() {
         JSignedInteger sIntTest = new JSignedInteger();
 
-        assertEquals(null, sIntTest.getName());
+        assertEquals("Signed Integer", sIntTest.getName());
         sIntTest.setName("test_name");
         assertEquals("test_name", sIntTest.getName());
     }

--- a/src/com/twojr/toolkit/test/JStringTest.java
+++ b/src/com/twojr/toolkit/test/JStringTest.java
@@ -23,9 +23,11 @@ public class JStringTest {
 
         String str = "Test";
 
+        byte[] strAsByte= {(byte) 0x54, (byte) 0x65, (byte) 0x73, (byte) 0x74};     // Test
         JString jString = new JString(EIGHT_BIT,str);
 
-        assertEquals(jString.toByte(),str.getBytes());
+        for(int i=0; i<strAsByte.length; i++)
+            assertEquals(strAsByte[i],jString.toByte()[i]);
 
     }
 
@@ -65,7 +67,7 @@ public class JStringTest {
 
         String output = "String Value: " + str + "\n";
 
-        assertEquals(jString.getValue(),output);
+        assertEquals(output, jString.print());
 
     }
 

--- a/src/com/twojr/toolkit/test/JUnsignedIntegerTest.java
+++ b/src/com/twojr/toolkit/test/JUnsignedIntegerTest.java
@@ -2,9 +2,13 @@ package com.twojr.toolkit.test;
 import static com.twojr.toolkit.JDataSizes.*;
 import static org.junit.Assert.*;
 
+import com.twojr.toolkit.DataTypes;
 import com.twojr.toolkit.JDataSizes;
 import com.twojr.toolkit.integer.JUnsignedInteger;
 import org.junit.Test;
+
+import javax.xml.crypto.Data;
+
 /**
  * Created by Joseph Haggerty on 1/20/2017.
  */
@@ -62,7 +66,7 @@ public class JUnsignedIntegerTest {
     public void evalueateGetId() {
         int value = 0;
         int size = 1;
-        int id = 1;
+        int id = DataTypes.UNSIGNED_EIGHT_BIT_INT;
         String name = "test_name";
 
         JUnsignedInteger sIntTest = new JUnsignedInteger(EIGHT_BIT,value);
@@ -74,7 +78,7 @@ public class JUnsignedIntegerTest {
         int value = 0;
         int size = 1;
         int id = 1;
-        String name = "test_name";
+        String name = "Unsigned Integer";
 
         JUnsignedInteger sIntTest = new JUnsignedInteger(EIGHT_BIT,value);
         assertEquals(name, sIntTest.getName());
@@ -128,7 +132,7 @@ public class JUnsignedIntegerTest {
     public void evaluateSetId() {
         JUnsignedInteger sIntTest = new JUnsignedInteger();
 
-        assertEquals(0, sIntTest.getId());
+        assertEquals(DataTypes.UNSIGNED_EIGHT_BIT_INT, sIntTest.getId());
         sIntTest.setId(12);
         assertEquals(12, sIntTest.getId());
     }
@@ -137,16 +141,16 @@ public class JUnsignedIntegerTest {
     public void evaluateSetSize() {
         JUnsignedInteger sIntTest = new JUnsignedInteger();
 
-        assertEquals(0, sIntTest.getSize());
-        sIntTest.setSize(1);
         assertEquals(1, sIntTest.getSize());
+        sIntTest.setSize(4);
+        assertEquals(4, sIntTest.getSize());
     }
 
     @Test
     public void evaluateSetName() {
         JUnsignedInteger sIntTest = new JUnsignedInteger();
 
-        assertEquals(null, sIntTest.getName());
+        assertEquals("Unsigned Integer", sIntTest.getName());
         sIntTest.setName("test_name");
         assertEquals("test_name", sIntTest.getName());
     }


### PR DESCRIPTION
Fixed JDataSizes enum alignment, NULL: 0, EIGHT_BIT: 1 etc
Fixed unit tests to pass except for JBitmap, still needs work.
Made changes to library files and created better tests for toByte methods.
#103 